### PR TITLE
feat: add OFDMA calculation webpage

### DIFF
--- a/ofdma.html
+++ b/ofdma.html
@@ -1,0 +1,465 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+
+    <!--<style>
+.table-container {
+  width: 100%;
+  overflow: scroll;
+}
+table {
+  width: 100%;
+}
+        .table-container {
+  margin: auto;
+  max-width: 1200px;
+  min-height: 100vh;
+  overflow: scroll;
+  width: 100%;
+}
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+thead tr {
+  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #ddd;
+  height: 1px;
+}
+th {
+  font-weight: bold;
+  height: inherit;
+  padding: 0;
+}
+th:not(:first-of-type) {
+  border-left: 1px solid #ddd;
+}
+th button {
+  background-color: #eee;
+  border: none;
+  cursor: pointer;
+  display: block;
+  font: inherit;
+  height: 100%;
+  margin: 0;
+  min-width: max-content;
+  padding: 0.5rem 1rem;
+  position: relative;
+  text-align: left;
+  width: 100%;
+}
+tbody tr {
+  border-bottom: 1px solid #ddd;
+}
+td {
+  padding: 0.5rem 1rem;
+  text-align: left;
+}
+    </style>-->
+    <style>
+        .sortable thead th:not(.no-sort) {
+            cursor: pointer
+        }
+
+        .sortable thead th:not(.no-sort)::after,
+        .sortable thead th:not(.no-sort)::before {
+            transition: color .1s ease-in-out;
+            font-size: 1.2em;
+            color: rgba(0, 0, 0, 0)
+        }
+
+        .sortable thead th:not(.no-sort)::after {
+            margin-left: 3px;
+            content: "▸"
+        }
+
+        .sortable thead th:not(.no-sort):hover::after {
+            color: inherit
+        }
+
+        .sortable thead th:not(.no-sort).dir-d::after {
+            color: inherit;
+            content: "▾"
+        }
+
+        .sortable thead th:not(.no-sort).dir-u::after {
+            color: inherit;
+            content: "▴"
+        }
+
+        .sortable thead th:not(.no-sort).indicator-left::after {
+            content: ""
+        }
+
+        .sortable thead th:not(.no-sort).indicator-left::before {
+            margin-right: 3px;
+            content: "▸"
+        }
+
+        .sortable thead th:not(.no-sort).indicator-left:hover::before {
+            color: inherit
+        }
+
+        .sortable thead th:not(.no-sort).indicator-left.dir-d::before {
+            color: inherit;
+            content: "▾"
+        }
+
+        .sortable thead th:not(.no-sort).indicator-left.dir-u::before {
+            color: inherit;
+            content: "▴"
+        }
+
+        .sortable {
+            --stripe-color: #e4e4e4;
+            --th-color: #fff;
+            --th-bg: #808080;
+            --td-color: #000;
+            --td-on-stripe-color: #000;
+            border-spacing: 0
+        }
+
+        .sortable tbody tr:nth-child(odd) {
+            background-color: var(--stripe-color);
+            color: var(--td-on-stripe-color)
+        }
+
+        .sortable thead th {
+            background: var(--th-bg);
+            color: var(--th-color);
+            font-weight: normal;
+            text-align: left;
+            text-transform: capitalize;
+            vertical-align: baseline;
+            white-space: nowrap
+        }
+
+        .sortable td {
+            color: var(--td-color)
+        }
+
+        .sortable td,
+        .sortable th {
+            padding: 10px
+        }
+
+        .sortable td:first-child,
+        .sortable th:first-child {
+            border-top-left-radius: 4px
+        }
+
+        .sortable td:last-child,
+        .sortable th:last-child {
+            border-top-right-radius: 4px
+        }
+
+        /*# sourceMappingURL=sortable.min.css.map */
+    </style>
+    <script>
+        /**
+ * sortable v2.3.2
+ *
+ * https://www.npmjs.com/package/sortable-tablesort
+ * https://github.com/tofsjonas/sortable
+ *
+ * Makes html tables sortable, No longer ie9+ 😢
+ *
+ * Styling is done in css.
+ *
+ * Copyleft 2017 Jonas Earendel
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org>
+ *
+ */
+        document.addEventListener('click', function (e) {
+            try {
+                // allows for elements inside TH
+                function findElementRecursive(element, tag) {
+                    return element.nodeName === tag ? element : findElementRecursive(element.parentNode, tag);
+                }
+                var descending_th_class_1 = 'dir-d';
+                var ascending_th_class_1 = 'dir-u';
+                var ascending_table_sort_class = 'asc';
+                var no_sort_class = 'no-sort';
+                var null_last_class = 'n-last';
+                var table_class_name = 'sortable';
+                var alt_sort_1 = e.shiftKey || e.altKey;
+                var element = findElementRecursive(e.target, 'TH');
+                var tr = element.parentNode;
+                var thead = tr.parentNode;
+                var table = thead.parentNode;
+                function reClassify(element, dir) {
+                    element.classList.remove(descending_th_class_1);
+                    element.classList.remove(ascending_th_class_1);
+                    if (dir)
+                        element.classList.add(dir);
+                }
+                function getValue(element) {
+                    var _a;
+                    var value = alt_sort_1 ? element.dataset.sortAlt : (_a = element.dataset.sort) !== null && _a !== void 0 ? _a : element.textContent;
+                    return value;
+                }
+                if (thead.nodeName === 'THEAD' && // sortable only triggered in `thead`
+                    table.classList.contains(table_class_name) &&
+                    !element.classList.contains(no_sort_class) // .no-sort is now core functionality, no longer handled in CSS
+                ) {
+                    var column_index_1;
+                    var nodes = tr.cells;
+                    var tiebreaker_1 = parseInt(element.dataset.sortTbr);
+                    // Reset thead cells and get column index
+                    for (var i = 0; i < nodes.length; i++) {
+                        if (nodes[i] === element) {
+                            column_index_1 = parseInt(element.dataset.sortCol) || i;
+                        }
+                        else {
+                            reClassify(nodes[i], '');
+                        }
+                    }
+                    var dir = descending_th_class_1;
+                    // Check if we're sorting ascending or descending
+                    if (element.classList.contains(descending_th_class_1) ||
+                        (table.classList.contains(ascending_table_sort_class) && !element.classList.contains(ascending_th_class_1))) {
+                        dir = ascending_th_class_1;
+                    }
+                    // Update the `th` class accordingly
+                    reClassify(element, dir);
+                    var reverse_1 = dir === ascending_th_class_1;
+                    var sort_null_last_1 = table.classList.contains(null_last_class);
+                    var compare_1 = function (a, b, index) {
+                        var x = getValue(b.cells[index]);
+                        var y = getValue(a.cells[index]);
+                        if (sort_null_last_1) {
+                            if (x === '' && y !== '') {
+                                return -1;
+                            }
+                            if (y === '' && x !== '') {
+                                return 1;
+                            }
+                        }
+                        var temp = Number(x) - Number(y);
+                        var bool = isNaN(temp) ? x.localeCompare(y) : temp;
+                        return reverse_1 ? -bool : bool;
+                    };
+                    // loop through all tbodies and sort them
+                    for (var i = 0; i < table.tBodies.length; i++) {
+                        var org_tbody = table.tBodies[i];
+                        // Put the array rows in an array, so we can sort them...
+                        var rows = [].slice.call(org_tbody.rows, 0);
+                        // Sort them using Array.prototype.sort()
+                        rows.sort(function (a, b) {
+                            var bool = compare_1(a, b, column_index_1);
+                            return bool === 0 && !isNaN(tiebreaker_1) ? compare_1(a, b, tiebreaker_1) : bool;
+                        });
+                        // Make an empty clone
+                        var clone_tbody = org_tbody.cloneNode();
+                        // Put the sorted rows inside the clone
+                        clone_tbody.append.apply(clone_tbody, rows);
+                        // And finally replace the unsorted tbody with the sorted one
+                        table.replaceChild(clone_tbody, org_tbody);
+                    }
+                }
+            }
+            catch (error) {
+                // console.log(error)
+            }
+        });
+    </script>
+</head>
+
+<body>
+    <table>
+        <tbody>
+            <tr>
+                <th>Start Frequency (MHz)</th>
+                <td><input type="number" id="startFrequency" /></td>
+            </tr>
+            <tr>
+                <th>End Frequency (MHz)</th>
+                <td><input type="number" id="endFrequency" /></td>
+            </tr>
+            <tr>
+                <th>Subcarrier Spacing</th>
+                <td><select id="subcarrierSpacing">
+                        <option value="25,50">Any</option>
+                        <option value="50">50</option>
+                        <option value="25">25</option>
+                    </select></td>
+            </tr>
+            <tr>
+                <th>Modulation Order</th>
+                <td><select id="modulationOrder">
+                        <option value="2,3,4,5,6,7,8,9,10,11,12">Any</option>
+                        <option value="2">qpsk</option>
+                        <option value="3">8qam</option>
+                        <option value="4">16qam</option>
+                        <option value="5">32qam</option>
+                        <option value="6">64qam</option>
+                        <option value="7">128qam</option>
+                        <option value="8">256qam</option>
+                        <option value="9">512qam</option>
+                        <option value="10">1024qam</option>
+                        <option value="11">2048qam</option>
+                        <option value="12">4096qam</option>
+                    </select></td>
+            </tr>
+            <tr>
+                <th>Cyclic Prefix</th>
+                <td><select id="cyclicPrefix">
+                        <option value="96,128,160,192,224,256,288,320,384,512,640">Any</option>
+                        <option value="96">96</option>
+                        <option value="128">128</option>
+                        <option value="160">160</option>
+                        <option value="192">192</option>
+                        <option value="224">224</option>
+                        <option value="256">256</option>
+                        <option value="288">288</option>
+                        <option value="320">320</option>
+                        <option value="384">384</option>
+                        <option value="512">512</option>
+                        <option value="640">640</option>
+                    </select></td>
+            </tr>
+            <tr>
+                <th></th>
+                <td><button id="run" onclick="calc()">Recalculate</button></td>
+            </tr>
+        </tbody>
+    </table>
+    <table id="output" style="width:100%;border: 1px solid black;" class="sortable">
+        <thead>
+            <tr>
+                <th>Subcarrier Spacing (KHz)</th>
+                <th>Modulation (QAM)</th>
+                <th>Cyclic Prefix</th>
+                <th>Upstream Channel Capacity (Mbps)</th>
+            </tr>
+        </thead>
+        <tbody id="list_tbody"></tbody>
+    </table>
+    <script>
+        const MINISLOT_PATTERNS = [
+            [1, 8, 0, 2, 2], [2, 8, 0, 4, 2], [3, 8, 0, 8, 2], [4, 8, 0, 16, 2], [5, 8, 0, 1, 1],
+            [6, 8, 0, 2, 1], [7, 8, 0, 4, 1], [1, 8, 1, 4, 4], [2, 8, 1, 6, 4], [3, 8, 1, 10, 4],
+            [4, 8, 1, 16, 4], [5, 8, 1, 2, 2], [6, 8, 1, 3, 2], [7, 8, 1, 5, 2], [8, 16, 0, 2, 2],
+            [9, 16, 0, 4, 2], [10, 16, 0, 8, 2], [11, 16, 0, 16, 2], [12, 16, 0, 1, 1], [13, 16, 0, 2, 1],
+            [14, 16, 0, 4, 1], [8, 16, 1, 4, 4], [9, 16, 1, 6, 4], [10, 16, 1, 10, 4], [11, 16, 1, 18, 4],
+            [12, 16, 1, 2, 2], [13, 16, 1, 3, 2], [14, 16, 1, 5, 2]
+        ];
+
+        /**
+         * Calculate the OFDMA upstream channel capacity (in Mbps) based on the provided arguments
+         * @returns {number} Upstream channel capacity in Mbps (index 1)
+         * @param {number} startFrequency - Starting frequency of the OFDMA block in MHz
+         * @param {number} endFrequency - End frequency of the OFDMA block in MHz
+         * @param {number} modulationOrder - Modulation order, value between 2 and 12 (inclusive)
+         * @param {number} usCyclicPrefix - Number of cyclic prefix samples
+         * @param {number} usSubcarrierSpacing - Spacing between OFDMA subcarriers in KHz
+        */
+        function ofdmaCapacity(startFrequency, endFrequency, modulationOrder, usSubcarrierSpacing, usCyclicPrefix, usPilotPattern = 8, usSamplingRate = 102.4, usMinislotSymbolsK = 36, usNumContLegacy = 1, usExcludedSpectrum = 0, usGuardBand = 1, usExcludedNbi = 0, usAdditionalEdgeMinislot = 0, usNumGrantsInProfile = 38) {
+            const occupiedSpectrum = endFrequency - startFrequency;
+            const activeBandwidth = occupiedSpectrum - usExcludedSpectrum;
+            const cyclicPrefixMicroseconds = usCyclicPrefix / usSamplingRate;
+            const symbolPeriodMicroseconds = 1000 / usSubcarrierSpacing;
+            const actualSymbolPeriodMicroseconds = symbolPeriodMicroseconds + cyclicPrefixMicroseconds;
+            const [minislotSubcarriersQ, kNbi] = usSubcarrierSpacing === 25 ? [16, 3] : [8, 2];
+            const totalSubcarriers = 1000 * occupiedSpectrum / usSubcarrierSpacing;
+            const excludedSubcarriers = (1000 * (usExcludedSpectrum + usGuardBand) / usSubcarrierSpacing) + (usExcludedNbi + kNbi);
+            const numExcludedSpectrumGaps = usExcludedNbi + usNumContLegacy;
+            const actualSignalSubcarriers = totalSubcarriers - excludedSubcarriers;
+            const tempNumMinislots = Math.floor(actualSignalSubcarriers / minislotSubcarriersQ);
+            const minislotEfficiency = (actualSignalSubcarriers - numExcludedSpectrumGaps * 4) / actualSignalSubcarriers;
+            const numMinislots = Math.round(minislotEfficiency * tempNumMinislots);
+            const numEdgeMinislots = usNumGrantsInProfile + usAdditionalEdgeMinislot;
+            const numBodyMinislots = numMinislots - numEdgeMinislots;
+
+            const localPilotPattern = minislotSubcarriersQ !== 16 ? usPilotPattern - 1 : usPilotPattern + 6;
+            const upstreamCapacity = (numBodyMinislots * minislotCapacity(usMinislotSymbolsK, modulationOrder, localPilotPattern)) + (numEdgeMinislots * minislotCapacity(usMinislotSymbolsK, modulationOrder, localPilotPattern + 7));
+
+            return upstreamCapacity / (usMinislotSymbolsK * actualSymbolPeriodMicroseconds);
+        }
+
+        /**
+         * Calculates the minislot capacity based on the given parameters.
+         * @returns {number} Minislot capacity
+         * @param {number} minislotSymbolsK
+         * @param {number} modulationOrder
+         * @param {number} patternIndex - Index into the `MINISLOT_PATTERNS` array constant
+        */
+        function minislotCapacity(minislotSymbolsK, modulationOrder, patternIndex) {
+            const minislotPattern = MINISLOT_PATTERNS[patternIndex];
+            const q = minislotPattern[1];
+            const cyclicPrefixModulationOrder = Math.max(modulationOrder - 4, 1);
+            const subcarriers = minislotSymbolsK * q - minislotPattern[3] - minislotPattern[4];
+            return modulationOrder * subcarriers + cyclicPrefixModulationOrder + minislotPattern[4];
+        }
+
+        function createElementWithId(tagName, id) {
+            var elem = document.createElement(tagName);
+            var attr = document.createAttribute("id");
+            attr.nodeValue = id;
+            elem.setAttributeNode(attr);
+            return elem;
+        }
+
+        function calc() {
+            const table = document.getElementById("output");
+
+            const startFrequency = parseFloat(document.getElementById("startFrequency").value);
+            const endFrequency = parseFloat(document.getElementById("endFrequency").value);
+            const arrModulationOrder = String(document.getElementById('modulationOrder').value).split(',').map(el => parseInt(el));
+            const arrCyclicPrefix = String(document.getElementById('cyclicPrefix').value).split(',').map(el => parseInt(el));
+            const arrSubcarrierSpacing = String(document.getElementById('subcarrierSpacing').value).split(',').map(el => parseInt(el));
+            var oldtbody = table.tBodies[0]
+            while (oldtbody.hasChildNodes()) {
+                oldtbody.removeChild(oldtbody.lastChild);
+            }
+            results = [];
+            arrSubcarrierSpacing.forEach((subcarrierSpacing) => {
+                arrModulationOrder.forEach((modulationOrder) => {
+                    arrCyclicPrefix.forEach((cyclicPrefix) => {
+                        const result = ofdmaCapacity(startFrequency, endFrequency, modulationOrder, subcarrierSpacing, cyclicPrefix);
+                        results.push(result);
+                        let row = table.tBodies[0].insertRow();
+
+                        let subSpacingCell = row.insertCell();
+                        subSpacingCell.appendChild(document.createTextNode(subcarrierSpacing));
+                        let modulationCell = row.insertCell();
+                        let text = document.createTextNode(modulationOrder === 2 ? "qpsk" : `${Math.pow(2, modulationOrder)}qam`);
+                        modulationCell.appendChild(text);
+                        let cyclicPrefixCell = row.insertCell();
+                        cyclicPrefixCell.appendChild(document.createTextNode(cyclicPrefix));
+                        let upstreamCapacityMbps = row.insertCell();
+                        upstreamCapacityMbps.appendChild(document.createTextNode(result.toFixed(3)));
+                    });
+                });
+            });
+        }
+        calc();
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
a coworker of mine asked me to port the OFDMA Python script to a webpage similar to the OFDM one, so this adds that. I'm not a network engineer so most of the meaning behind the terms went over my head :sweat_smile: so I had him give me some defaults for most of the parameters and only made some of the values configurable on the page, figured someone could add dropdowns etc for those in the future if needed. the code is basically a 1-1 port of the Python script excluding the PHY efficiency since he only needed the capacity estimations. if there's anything that looks wrong or you want fixed, let me know, but I spot checked it against the Python script and it seems like it should be equivalent.